### PR TITLE
IOS version check added to check if the device supports devicemotionevent.requestPermission() function

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -96,7 +96,7 @@ class Home extends React.Component {
           });
         }
       })
-    } else if( /Android|webOS|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+    } else if( /iPhone|iPod|iPad|Android|webOS|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
         this.setState({
           accPermission: true, // Permission to access Accelerometer data is given by the receiver
         });

--- a/client/src/components/SendFiles.js
+++ b/client/src/components/SendFiles.js
@@ -84,7 +84,7 @@ class SendFiles extends React.Component {
         }
         this.createTorrent(accResponse);
       })
-    } else if( /Android|webOS|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+    } else if( /iPhone|iPod|iPad|Android|webOS|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
       accResponse = true
       this.createTorrent(accResponse);
     } else {


### PR DESCRIPTION
# Changes
Added a function that returns the function of the IOS devices.
Using that function, a version check added before asking for permission to access accelerometer data.

# Testing
Just try to make a file transfer and make sure my implementation didn't affect Android and desktop devices. I tested on my older IOS, and now I get a different error on my local host. However, I don't get the error below anymore.
![Screen Shot 2022-05-26 at 10 50 03 AM](https://user-images.githubusercontent.com/51714575/170546391-bf9564dd-360b-4b42-8cbd-369c6968df9a.png)

The new error I get on my local host is
![Screen Shot 2022-05-26 at 10 43 44 AM](https://user-images.githubusercontent.com/51714575/170546477-a23f6771-1c7e-4b1d-9863-6473e6789fb7.png)
However, I don't get this error on bambam.app. Therefore, I believe when we merge this into main, my older IOS device will be able to use our app.

If you can run my branch on bambam.app temporarily without merging it into the main branch, I may be able to test it.
